### PR TITLE
Check for <testsuites> vs <testsuite> root tag. Fixes #9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,4 @@ dist/
 *.egg-info/
 .coverage
 .venv/
-*.xml
 build/

--- a/tcms_junit_plugin/__init__.py
+++ b/tcms_junit_plugin/__init__.py
@@ -14,7 +14,18 @@ class Plugin:  # pylint: disable=too-few-public-methods
         self.backend.configure()
 
         xml = JUnitXml.fromfile(junit_xml)
-        for xml_case in xml:
+        # apparently junit.xml may contain either a <testsuites> tag,
+        # e.g. Katalon Studio
+        if xml._tag == "testsuites":  # pylint: disable=protected-access
+            cases = []
+            for suite in xml:
+                for case in suite:
+                    cases.append(case)
+        # or directly <testsuite> (only 1) tag - nose & py.test
+        else:
+            cases = list(xml)
+
+        for xml_case in cases:
             summary = "%s.%s" % (xml_case.classname, xml_case.name)
 
             test_case = self.backend.test_case_get_or_create(summary)

--- a/tests/bin/make-junit.xml
+++ b/tests/bin/make-junit.xml
@@ -18,3 +18,6 @@ export TCMS_BUILD="$TRAVIS_BUILD_NUMBER-$(echo $TRAVIS_COMMIT | cut -c1-7)"
 
 nosetests --with-xunit
 ./tcms-junit.xml-plugin nosetests.xml
+
+# parse additional data files collected from issues
+./tcms-junit.xml-plugin tests/data/9.xml

--- a/tests/data/9.xml
+++ b/tests/data/9.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<testsuites name="Login test suite with data-driven-approach" time="102" tests="0" failures="1" errors="0">
+   <testsuite name="Login test suite with data-driven-approach" tests="0" failures="1" errors="0" time="102" timestamp="2019-05-15 10:46:05" hostname="hostname" id="Test Suites/Simple Examples/Login test suite with data-driven-approach">
+       <properties>
+           <property name="deviceName" value=""/>
+           <property name="devicePlatform" value=""/>
+           <property name="os" value="Windows 10 64bit"/>
+           <property name="katalonVersion" value="6.1.5.3"/>
+           <property name="browser" value="Chrome 74.0.3729.131"/>
+           <property name="hostAddress" value="10.0.75.1"/>
+           <property name="sessionId" value="be95c805dbf972b86c5e147e4cf50990"/>
+           <property name="seleniumVersion" value="3.7.1"/>
+           <property name="proxyInformation" value="ProxyInformation{proxyOption=NO_PROXY, proxyServerType=HTTP, password=, proxyServerAddress=, proxyServerPort=0}"/>
+           <property name="platform" value="Windows 10"/>
+       </properties>
+       <testcase name="will always report FAILED" classname="Parser test for Issue #9" status="FAILED">
+           <failure type="FAILED" message="Test Cases/Simple Examples/Login Test/Data-driven examples/Login with username and password as a default value of variables FAILED.&#xA;Reason:&#xA;com.kms.katalon.core.exception.StepFailedException: Unable to verify text 'System dashboard' is present &#xD;&#xA;&#x9;at "/>
+           <system-out>2019-05-15 10:46:06 - [TEST_CASE][FAILED] - Test Cases/Simple Examples/Login Test/Data-driven examples/Login with username and password as a default value of variables: Test Cases/Simple Examples/Login Test/Data-driven examples/Login with username and password as a default value of variables FAILED.</system-out>
+           <system-err>2019-05-15 10:46:06 - [TEST_CASE][FAILED] - Test Cases/Simple Examples/Login Test/Data-driven examples/Login with username and password as a default value of variables: Test Cases/Simple Examples/Login Test/Data-driven examples/Login with username and password as a default value of variables FAILED.</system-err>
+       </testcase>
+       <system-out>2019-05-15 10:46:05 - [TEST_SUITE][INCOMPLETE] - Login test suite with data-driven-approach: null</system-out>
+       <system-err>2019-05-15 10:46:05 - [TEST_SUITE][INCOMPLETE] - Login test suite with data-driven-approach: null</system-err>
+   </testsuite>
+</testsuites>


### PR DESCRIPTION
According to the JUnit XML specs:
https://www.ibm.com/support/knowledgecenter/en/SSUFAU_1.0.0/com.ibm.rsar.analysis.codereview.cobol.doc/topics/cac_useresults_junit.html

the root element in the XML is a <testsuites> tag. However some
of the test runners we've used skip that and have a single
<testsuite> tag as their root node. This causes failures for
people using some of the other test runners, e.g.

- Katalon Studio - exports with the <testsuites> tag
- Nose, py.test - export results with the <testsuite> tag