### PR TITLE
Allow conversion from xml testcase to summary to be templated via commandline.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -100,6 +100,12 @@ Usage
 Changelog
 ---------
 
+NEXT
+~~~~
+
+- Provide a ``--summary-template`` for optional customization of the
+  summary generated from the test cases. 
+
 v11.3 (18 May 2022)
 ~~~~~~~~~~~~~~~~~~~
 

--- a/README.rst
+++ b/README.rst
@@ -104,7 +104,7 @@ NEXT
 ~~~~
 
 - Provide a ``--summary-template`` for optional customization of the
-  summary generated from the test cases. 
+  summary generated from the test cases.
 
 v11.3 (18 May 2022)
 ~~~~~~~~~~~~~~~~~~~

--- a/tcms_junit_plugin/__init__.py
+++ b/tcms_junit_plugin/__init__.py
@@ -4,6 +4,7 @@
 import argparse
 
 from junitparser import Error, Failure, JUnitXml, Skipped
+from string import Template
 from tcms_api import plugin_helpers
 
 from .version import __version__
@@ -15,8 +16,9 @@ class Backend(plugin_helpers.Backend):
 
 
 class Plugin:  # pylint: disable=too-few-public-methods
-    def __init__(self, verbose=False):
+    def __init__(self, summary_template, verbose=False):
         self.backend = Backend(prefix='[junit.xml]', verbose=verbose)
+        self.summary_template = summary_template
         self.verbose = verbose
 
     def parse(
@@ -42,8 +44,13 @@ class Plugin:  # pylint: disable=too-few-public-methods
             else:
                 cases = list(xml)
 
+            summary_template = Template(self.summary_template)
             for xml_case in cases:
-                summary = f"{xml_case.classname}.{xml_case.name}"[:255]
+                # Only permit non-secret values in this map
+                # Users with template control can retrieve any value set here.
+                values = {"classname": xml_case.classname, "name": xml_case.name}
+
+                summary = summary_template.substitute(values)[:255]
 
                 test_case, _ = self.backend.test_case_get_or_create(summary)
                 self.backend.add_test_case_to_plan(test_case['id'],
@@ -93,10 +100,13 @@ def main(argv):
     )
     parser.add_argument('-v', '--verbose', dest='verbose', action='store_true',
                         help='Print information about created TP/TR records')
+    parser.add_argument('--summary-template', dest='summary_template', type=str,
+                        help='Template to convert testcase to summary, eg %(default)s.',
+                        default='${classname}.${name}')
     parser.add_argument('filename.xml', type=str, nargs='+',
                         help='XML file(s) to parse')
 
     args = parser.parse_args(argv[1:])
 
-    plugin = Plugin(verbose=args.verbose)
+    plugin = Plugin(args.summary_template, verbose=args.verbose)
     plugin.parse(getattr(args, 'filename.xml'))

--- a/tcms_junit_plugin/__init__.py
+++ b/tcms_junit_plugin/__init__.py
@@ -54,8 +54,10 @@ class Plugin:  # pylint: disable=too-few-public-methods
                 # Only permit non-secret values in this map
                 # Users with template control can retrieve any value set here.
                 values = {
-                    "classname": xml_case.classname, "name": xml_case.name,
-                    "suitename": xml_case.suitename}
+                    "classname": xml_case.classname,
+                    "name": xml_case.name,
+                    "suitename": xml_case.suitename
+                }
 
                 summary = summary_template.substitute(values)[:255]
 

--- a/tcms_junit_plugin/__init__.py
+++ b/tcms_junit_plugin/__init__.py
@@ -39,6 +39,9 @@ class Plugin:  # pylint: disable=too-few-public-methods
                 cases = []
                 for suite in xml:
                     for case in suite:
+                        # Retain the suite name (if present) with each testcase.
+                        if suite.name:
+                            case.suitename = suite.name
                         cases.append(case)
             # or directly <testsuite> (only 1) tag - nose & py.test
             else:
@@ -48,7 +51,9 @@ class Plugin:  # pylint: disable=too-few-public-methods
             for xml_case in cases:
                 # Only permit non-secret values in this map
                 # Users with template control can retrieve any value set here.
-                values = {"classname": xml_case.classname, "name": xml_case.name}
+                values = {
+                    "classname": xml_case.classname, "name": xml_case.name,
+                    "suitename": xml_case.suitename}
 
                 summary = summary_template.substitute(values)[:255]
 

--- a/tcms_junit_plugin/__init__.py
+++ b/tcms_junit_plugin/__init__.py
@@ -16,10 +16,11 @@ class Backend(plugin_helpers.Backend):
 
 
 class Plugin:  # pylint: disable=too-few-public-methods
-    def __init__(self, summary_template, verbose=False):
+    def __init__(self, verbose=False, summary_template='$classname.$name'):
         self.backend = Backend(prefix='[junit.xml]', verbose=verbose)
-        self.summary_template = summary_template
         self.verbose = verbose
+        # NB: template is defaulted both here and in the argument parser below
+        self.summary_template = summary_template
 
     def parse(
         self,
@@ -39,7 +40,8 @@ class Plugin:  # pylint: disable=too-few-public-methods
                 cases = []
                 for suite in xml:
                     for case in suite:
-                        # Retain the suite name (if present) with each testcase.
+                        # Retain the suite name (if present) with each
+                        # testcase.
                         if suite.name:
                             case.suitename = suite.name
                         cases.append(case)
@@ -105,13 +107,16 @@ def main(argv):
     )
     parser.add_argument('-v', '--verbose', dest='verbose', action='store_true',
                         help='Print information about created TP/TR records')
-    parser.add_argument('--summary-template', dest='summary_template', type=str,
-                        help='Template to convert testcase to summary, eg %(default)s.',
+    # NB: template is defaulted both here and in the Plugin init method above
+    parser.add_argument('--summary-template', dest='summary_template',
+                        type=str,
+                        help='Template summary from testcase, eg %(default)s.',
                         default='${classname}.${name}')
     parser.add_argument('filename.xml', type=str, nargs='+',
                         help='XML file(s) to parse')
 
     args = parser.parse_args(argv[1:])
 
-    plugin = Plugin(args.summary_template, verbose=args.verbose)
+    plugin = Plugin(verbose=args.verbose,
+                    summary_template=args.summary_template)
     plugin.parse(getattr(args, 'filename.xml'))


### PR DESCRIPTION
We have some generated junit xml files that we want to upload where the information in the classname is duplicated in the name. This is in many ways a bug in the junit file, but allowing some basic templating will permit this to be worked around without reworking the junit file generation, which is used by other tools.

For example our junit contains entries like so (within a testsuites):
```
  <testsuite name="Hidden Setting Migration" timestamp="2023-03-08T17:11:02" tests="3" time="33.715" failures="0">
    <testcase name="Hidden Setting Migration should not migrate the lack of a labs flag" time="12.519" classname="should not migrate the lack of a labs flag">
    </testcase>
    <testcase name="Hidden Setting Migration should migrate labsHiddenRR=false as sendRR=true" time="9.572" classname="should migrate labsHiddenRR=false as sendRR=true">
    </testcase>
    <testcase name="Hidden Setting Migration should migrate labsHiddenRR=true as sendRR=false" time="8.834" classname="should migrate labsHiddenRR=true as sendRR=false">
    </testcase>
  </testsuite>
```

The way these were generated means that the testsuite name has been added into the testcase name - we kinda really just want either the testcase name, or the testsuite name + testcase classname. 

This change allows some basic templating to permit us to pass eg --summary-template "$name" to only use the name component.

I used string Template rather than f"strings" or similar, because Template has a strong control over which values are substituted, preventing accidental leaks of information from the tool - many other options would allow arbitrary variables to be used in the template.