### PR TITLE
Improved case summary formatting

### DIFF
--- a/tcms_junit_plugin/__init__.py
+++ b/tcms_junit_plugin/__init__.py
@@ -43,7 +43,10 @@ class Plugin:  # pylint: disable=too-few-public-methods
                 cases = list(xml)
 
             for xml_case in cases:
-                summary = f"{xml_case.classname}.{xml_case.name}"[:255]
+                if xml_case.classname:
+                    summary = f"{xml_case.classname}.{xml_case.name}"[:255]
+                else:
+                    summary = xml_case.name[:255]
 
                 test_case, _ = self.backend.test_case_get_or_create(summary)
                 self.backend.add_test_case_to_plan(test_case['id'],


### PR DESCRIPTION
The summary of the test case may be required to follow a certain convention depending on a development team. In our project, for example the following format for naming of test cases is used: Txxx-yy, where xxx is the test plan number and yy is the test case number.

Implementing such naming convention with the current version of junit.xml-plugin is not possible as it forces a "." at the beginning of the summary if no class name is provided. The code i propose fixes that problem.