### PR TITLE
Added decoding comment string before sending it to Backend

### DIFF
--- a/tcms_junit_plugin/__init__.py
+++ b/tcms_junit_plugin/__init__.py
@@ -97,7 +97,7 @@ class Plugin:  # pylint: disable=too-few-public-methods
                     test_case["id"],
                     self.backend.run_id,
                 ):
-                    self.backend.update_test_execution(execution["id"], status_id, comment)
+                    self.backend.update_test_execution(execution["id"], status_id, comment.decode())
 
                 if progress_cb:
                     progress_cb()


### PR DESCRIPTION
Comment is uploaded to Kiwi database as a string representation of a bytes object, which leads to poor readability as you can see here: [image1](https://postimg.cc/4KCsPbw8)

Decoding the bytes object and saving a proper string to the database significantly improves readability: https://postimg.cc/r0NVK01f